### PR TITLE
chore: add "calafex" as permanent reviewer in CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* calafex


### PR DESCRIPTION
Added "calafex" to the CODEOWNERS file, designating it as a code owner for the repository.